### PR TITLE
The original "Working Demo" link didn't.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Mass follow & profit w/ followers
 
-[Working demo](https://followr.herokuapp.com)
+[Working demo](http://twitterblast.herokuapp.com/)
 
 ## Development environment
 A `Dockerfile` and `docker-compose.yml` are provided with the app, allowing to boot a self-contained development environment.


### PR DESCRIPTION
The link now goes to an explanation page, with cautions. Better this than an error page.